### PR TITLE
mention search path order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation
 
 Download our
 [pre-built binaries](https://github.com/TeamVoss/VossII/releases/latest)
-and unpack them to your directory of choice, then put <installation-directory>/bin in your search path and you will be able to run the fl interpreter by simply invokng fl. Note that you need the <voss dir>/bin in your search path for the Verilog reader to work!
+and unpack them to your directory of choice, then put <installation-directory>/bin in your search path and you will be able to run the fl interpreter by simply invokng fl. Note that you need the <voss dir>/bin in your search path for the Verilog reader to work, and it must be earlier than any paths containing other versions of yosys!
 
 
 Voss II depends on Tk for its graphical bits. If the fl interpreter dies with


### PR DESCRIPTION
I put the VossII bin directory at the end of my search path, and it picked up my local build of yosys before the VossII build. Maybe the VossII-specific yosys build should have a different name? For now, I suggest this quick patch which at least mentions this potential problem in the README.