### PR TITLE
fix curly quotes in verilog example

### DIFF
--- a/src/doc/fl/fl_tutorial.md
+++ b/src/doc/fl/fl_tutorial.md
@@ -657,8 +657,8 @@ reg mux_out;
 always @*
 begin : MUX
   case(sel)
-    1’b0 : mux_out = din_0;
-    1’b1 : mux_out = din_1;
+    1'b0 : mux_out = din_0;
+    1'b1 : mux_out = din_1;
   endcase
 end
 endmodule


### PR DESCRIPTION
There are curly quotes in the verilog code in the README; replace them. I did not include an update to the prebuilt html in doc/, because the diff is huge and I guess there's some difference in our pandoc environments or locale or something - for example, &quot;fl&quot; in my local version, but the prebuilt html in the repo has curly-quotes-style “fl”. So please update the prebuilt html too (or I can try working out why my output differs..).