### PR TITLE
Dlesbre/small changes

### DIFF
--- a/IDVII/src/fl/design/hfl.fl
+++ b/IDVII/src/fl/design/hfl.fl
@@ -1368,12 +1368,12 @@ let core_TYPE name size is_arithmetic value_list =
 	let hw_`name`_destr (BV_`name` w) = w;
 	let {`name`_hw_type_destr:: {`name`} hw_type} =
 	    HW_TYPE hw_`name`_type_name
-		    hw_`name`_mk_var 
-		    hw_`name`_is_arithmetic 
-		    hw_`name`_size 
-		    hw_`name`_destr 
-		    hw_`name`_constr 
-		    hw_`name`_values 
+		    hw_`name`_mk_var
+		    hw_`name`_is_arithmetic
+		    hw_`name`_size
+		    hw_`name`_destr
+		    hw_`name`_constr
+		    hw_`name`_values
 	;
 	add_open_overload hw_type_destr `name`_hw_type_destr;
 	let `name`_input body_fun {fs::string} acc {a::`name`} =
@@ -1725,12 +1725,12 @@ let MEMORY name size_list word_type =
 	let hw_`name`_destr (BV_`name` w) = w;
 	let `name`_hw_type_destr =
 	    HW_TYPE hw_`name`_type_name
-		    hw_`name`_mk_var 
-		    hw_`name`_is_arithmetic 
-		    hw_`name`_size 
-		    hw_`name`_destr 
-		    hw_`name`_constr 
-		    hw_`name`_values 
+		    hw_`name`_mk_var
+		    hw_`name`_is_arithmetic
+		    hw_`name`_size
+		    hw_`name`_destr
+		    hw_`name`_constr
+		    hw_`name`_values
 	;
 	add_open_overload hw_type_destr `name`_hw_type_destr;
 	let `name`_input body_fun {fs::string} acc {a::`name`} =
@@ -1846,7 +1846,7 @@ let '~' a = wNOT a;
 
 let wAND {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let res = W_AND (hw_destr a) (hw_destr b) in
@@ -1857,7 +1857,7 @@ infix 4 '&';
 
 let wITE {c::bit} {t:: *a} {e:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let res = W_ITE (hw_bit_destr c) (hw_destr t) (hw_destr e) in
@@ -1880,7 +1880,7 @@ if_then_else_binder THEN ELSE;
 
 let wOR {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let res = W_OR (hw_destr a) (hw_destr b) in
@@ -1895,7 +1895,7 @@ infix 4 '^';
 
 let wEQ {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let res = W_EQ (hw_destr a) (hw_destr b) in
@@ -1906,7 +1906,7 @@ infix 5 '=';
 
 let wNEQ {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let res = W_NOT (W_EQ (hw_destr a) (hw_destr b)) in
@@ -1917,7 +1917,7 @@ infix 5 '!=';
 
 let wGR {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -1943,7 +1943,7 @@ infix 5 '<=';
 
 let wADD {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -1957,7 +1957,7 @@ infix 7 '+';
 
 let wDIV {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -1971,7 +1971,7 @@ infix 8 '/';
 
 let wMUL {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -1986,7 +1986,7 @@ infix 8 '*';
 
 let wSUB {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -2000,7 +2000,7 @@ infix 7 '-';
 
 let wMOD {a:: *a} {b:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     NOT (hw_is_arithmetic a) =>
@@ -2065,7 +2065,7 @@ infix 9 '|>>';	    // Fixity???????
 
 let ZX {inp:: *a} =
     val (HW_TYPE ihw_type_name ihw_mk_var ihw_is_arithmetic
-		 ihw_size ihw_destr ihw_constr ihw_values) = 
+		 ihw_size ihw_destr ihw_constr ihw_values) =
 	{hw_type_destr :: {*q} hw_type}
     in
     val (HW_TYPE ohw_type_name ohw_mk_var ohw_is_arithmetic
@@ -2080,7 +2080,7 @@ let ZX {inp:: *a} =
 
 let SX {inp:: *a} =
     val (HW_TYPE ihw_type_name ihw_mk_var ihw_is_arithmetic
-		 ihw_size ihw_destr ihw_constr ihw_values) = 
+		 ihw_size ihw_destr ihw_constr ihw_values) =
 	{hw_type_destr :: {*q} hw_type}
     in
     val (HW_TYPE ohw_type_name ohw_mk_var ohw_is_arithmetic
@@ -2316,7 +2316,7 @@ let default = {'1::bit};
 // Covert a hardware type to a list of bits
 let tobits {t:: *a} =
     val (HW_TYPE hw_type_name hw_mk_var hw_is_arithmetic
-		 hw_size hw_destr hw_constr hw_values) = 
+		 hw_size hw_destr hw_constr hw_values) =
 	{hw_type_destr :: {*a} hw_type}
     in
     let sz = hw_size t in
@@ -3072,13 +3072,13 @@ let hw__pair__values {p:: *a # *b} = error "Not relevant";
 
 let hw_pair_hw_type_destr =
 	    HW_TYPE hw__pair__type_name
-		    hw__pair__mk_var 
-		    hw__pair__is_arithmetic 
-		    hw__pair__size 
-		    hw__pair__destr 
-		    hw__pair__constr 
+		    hw__pair__mk_var
+		    hw__pair__is_arithmetic
+		    hw__pair__size
+		    hw__pair__destr
+		    hw__pair__constr
 		    hw__pair__values
-; 
+;
 add_open_overload hw_type_destr hw_pair_hw_type_destr;
 
 
@@ -3089,10 +3089,10 @@ let hw_list_hw_type_destr =
 		    (error "Not defined for lists")
 		    (error "Not defined for lists")
 		    (error "Not defined for lists")
-		    hw__list__destr 
+		    hw__list__destr
 		    (error "Not defined for lists")
 		    (error "Not defined for lists")
-; 
+;
 add_open_overload hw_type_destr hw_list_hw_type_destr;
 
 let posedge clk = (T,clk);

--- a/IDVII/src/fl/design/hfl.fl
+++ b/IDVII/src/fl/design/hfl.fl
@@ -2072,7 +2072,11 @@ let ZX {inp:: *a} =
 		 ohw_size ohw_destr ohw_constr ohw_values) =
 	{hw_type_destr :: {*b} hw_type}
     in
+    let sz_in = ihw_size inp in
     let sz_out = ohw_size {undefined :: *b} in
+    (sz_in > sz_out)
+        => eprintf "ZX can't extend into smaller type (%d bits into %d bits)" sz_in sz_out
+        |
     let w_out = W_ZX sz_out (ihw_destr inp) in
     let out = ohw_constr w_out in
     {out :: *b}
@@ -2087,7 +2091,11 @@ let SX {inp:: *a} =
 		 ohw_size ohw_destr ohw_constr ohw_values) =
 	{hw_type_destr :: {*b} hw_type}
     in
+    let sz_in = ihw_size inp in
     let sz_out = ohw_size {undefined :: *b} in
+    (sz_in > sz_out)
+        => eprintf "SX can't extend into smaller type (%d bits into %d bits)" sz_in sz_out
+        |
     let w_out = W_SX sz_out (ihw_destr inp) in
     let out = ohw_constr w_out in
     {out :: *b}

--- a/IDVII/src/fl/design/util.fl
+++ b/IDVII/src/fl/design/util.fl
@@ -36,6 +36,11 @@ let bit_range_lsb (BR_SINGLE i) = i
 let bit_range_msb (BR_SINGLE i) = i
  /\ bit_range_msb (BR_SLICE msb _) = msb;
 
+// Prints a bit range to a string
+// format: "nb" or "msb:lsb"
+let sprint_bit_range (BR_SINGLE i) = int2str i
+ /\ sprint_bit_range (BR_SLICE msb lsb) = sprintf "%d:%d" msb lsb;
+
 // Groups indices into continous slices
 // Input: non-empty list of ints in decreasing order
 // Outputs list grouping continuous slices
@@ -56,9 +61,7 @@ let group_indices indices =
 // prints the results
 let pr_indices indices =
 	let ranges = group_indices indices in
-	let format (BR_SLICE msb lsb) = sprintf "%d:%d" msb lsb
-	 /\ format (BR_SINGLE index) = int2str index in
-    list2str T "[" "," "]" format ranges
+    list2str T "[" "," "]" sprint_bit_range ranges
 ;
 
 

--- a/IDVII/src/fl/design/util.fl
+++ b/IDVII/src/fl/design/util.fl
@@ -15,19 +15,19 @@ let is_user_given s =
 
 // A type to represent continous index ranges
 // and individual index bits
-lettype IndexRanges = SingleIndex int | IndexSlice {msb::int} {lsb::int};
+lettype index = SINGLE int | SLICE {msb::int} {lsb::int};
 
 // Groups indices into continous slices
 // Input: non-empty list of ints in decreasing order
 // Outputs list grouping continuous slices
-// Ex: [5,4,3,0] -> [IndexSlice 5 3, SingleIndex 0]
+// Ex: [5,4,3,0] -> [SLICE 5 3, SINGLE 0]
 let group_indices indices =
 	letrec merge msb cur (idx:rem) =
 		idx = cur-1 => merge msb idx rem |
-		msb > cur => (IndexSlice msb cur):(merge idx idx rem)
-		          |  (SingleIndex msb):(merge idx idx rem)
+		msb > cur => (SLICE msb cur):(merge idx idx rem)
+		          |  (SINGLE msb):(merge idx idx rem)
 	   /\  merge msb cur [] =
-		msb > cur => [IndexSlice msb cur] | [SingleIndex msb]
+		msb > cur => [SLICE msb cur] | [SINGLE msb]
 	in
 	let i0 = hd indices in
 	merge i0 i0 (tl indices)
@@ -37,8 +37,8 @@ let group_indices indices =
 // prints the results
 let pr_indices indices =
 	let ranges = group_indices indices in
-	let format (IndexSlice msb lsb) = sprintf "%d:%d" msb lsb
-	 /\ format (SingleIndex index) = int2str index in
+	let format (SLICE msb lsb) = sprintf "%d:%d" msb lsb
+	 /\ format (SINGLE index) = int2str index in
     list2str T "[" "," "]" format ranges
 ;
 

--- a/IDVII/src/fl/design/util.fl
+++ b/IDVII/src/fl/design/util.fl
@@ -13,20 +13,36 @@ let is_user_given s =
     NOT (str_is_substr "TmP_" s)
 ;
 
-let pr_indices indices =
-    letrec merge msb cur (idx:rem) =
-	idx = cur-1 => merge msb idx rem |
-	msb > cur => (sprintf "%d:%d" msb cur):(merge idx idx rem) |
-	(int2str msb):(merge idx idx rem)
-     /\    merge msb cur [] =
-	msb > cur => [(sprintf "%d:%d" msb cur)] | [(int2str msb)]
-    in
-    let i0 = hd indices then
-    let ranges = merge i0 i0 (tl indices) then
-    list2str T "[" "," "]" id ranges
+// A type to represent continous index ranges
+// and individual index bits
+lettype IndexRanges = SingleIndex int | IndexSlice {msb::int} {lsb::int};
+
+// Groups indices into continous slices
+// Input: non-empty list of ints in decreasing order
+// Outputs list grouping continuous slices
+// Ex: [5,4,3,0] -> [IndexSlice 5 3, SingleIndex 0]
+let group_indices indices =
+	letrec merge msb cur (idx:rem) =
+		idx = cur-1 => merge msb idx rem |
+		msb > cur => (IndexSlice msb cur):(merge idx idx rem)
+		          |  (SingleIndex msb):(merge idx idx rem)
+	   /\  merge msb cur [] =
+		msb > cur => [IndexSlice msb cur] | [SingleIndex msb]
+	in
+	let i0 = hd indices in
+	merge i0 i0 (tl indices)
 ;
 
-    
+// Groups indices by continous ranges and
+// prints the results
+let pr_indices indices =
+	let ranges = group_indices indices in
+	let format (IndexSlice msb lsb) = sprintf "%d:%d" msb lsb
+	 /\ format (SingleIndex index) = int2str index in
+    list2str T "[" "," "]" format ranges
+;
+
+
 let update_fn_get_lhs (W_UPDATE_FN lhs rhs) = lhs
  /\ update_fn_get_lhs (W_PHASE_DELAY lhs rhs) = lhs
 ;
@@ -390,7 +406,7 @@ cletrec w2bv sub w =
 		    let part = mk_part inside f cur in
 		    part@(collect new_inside idx idx idxs)
 		  /\   collect inside f cur [] =
-		    let part = mk_part inside f cur in 
+		    let part = mk_part inside f cur in
 		    part
 		in
 		let start = sz-1 in
@@ -427,7 +443,7 @@ cletrec w2bv sub w =
     w2bv w
 ;
 
-letrec wexpr2bool sub w = 
+letrec wexpr2bool sub w =
     let sz = wexpr_size w in
     let base = bv2list (w2bv sub w) in
     lastn sz ((replicate sz (hd base))@base)

--- a/IDVII/src/fl/design/util.fl
+++ b/IDVII/src/fl/design/util.fl
@@ -66,10 +66,6 @@ let pexlif_get_internals (PINST name attrs leaf fa_inps fa_outs ints cont) = int
 let pexlif_get_content (PINST name attrs leaf fa_inps fa_outs ints cont) = cont;
 let content_get_children (P_HIER children) = children;
 let content_get_leaf (P_LEAF fns) = fns;
-let update_fn_get_update_fun_lhs (W_UPDATE_FN lhs rhs) = lhs
- /\ update_fn_get_update_fun_lhs (W_PHASE_DELAY lhs rhs) = lhs;
-let update_fn_get_update_fun_rhs (W_UPDATE_FN lhs rhs) = rhs
- /\ update_fn_get_update_fun_rhs (W_PHASE_DELAY lhs rhs) = rhs;
 
 letrec prim_Ppexlif ind fp (inst,pexlif) =
     val (PINST name attrs leaf inps outs ints body) = pexlif then

--- a/IDVII/src/fl/design/util.fl
+++ b/IDVII/src/fl/design/util.fl
@@ -13,21 +13,40 @@ let is_user_given s =
     NOT (str_is_substr "TmP_" s)
 ;
 
-// A type to represent continous index ranges
+// A type to represent continous bit ranges
 // and individual index bits
-lettype index = SINGLE int | SLICE {msb::int} {lsb::int};
+lettype bit_range = BR_SINGLE int | BR_SLICE {msb::int} {lsb::int};
+
+// The size (in bits) of a bit range
+let bit_range_size (BR_SINGLE _) = 1
+ /\ bit_range_size (BR_SLICE msb lsb) = msb - lsb + 1;
+
+// Checks if a bit range contains a specific value
+let bit_range_contains (BR_SINGLE i) j = i == j
+ /\ bit_range_contains (BR_SLICE msb lsb) j =
+	msb > lsb
+		=> (msb >= j AND j >= lsb)
+		|  (lsb >= j AND j >= msb);
+
+// least significant bit position of a bit range
+let bit_range_lsb (BR_SINGLE i) = i
+ /\ bit_range_lsb (BR_SLICE _ lsb) = lsb;
+
+// least significant bit position of a bit range
+let bit_range_msb (BR_SINGLE i) = i
+ /\ bit_range_msb (BR_SLICE msb _) = msb;
 
 // Groups indices into continous slices
 // Input: non-empty list of ints in decreasing order
 // Outputs list grouping continuous slices
-// Ex: [5,4,3,0] -> [SLICE 5 3, SINGLE 0]
+// Ex: [5,4,3,0] -> [BR_SLICE 5 3, BR_SINGLE 0]
 let group_indices indices =
 	letrec merge msb cur (idx:rem) =
 		idx = cur-1 => merge msb idx rem |
-		msb > cur => (SLICE msb cur):(merge idx idx rem)
-		          |  (SINGLE msb):(merge idx idx rem)
+		msb > cur => (BR_SLICE msb cur):(merge idx idx rem)
+		          |  (BR_SINGLE msb):(merge idx idx rem)
 	   /\  merge msb cur [] =
-		msb > cur => [SLICE msb cur] | [SINGLE msb]
+		msb > cur => [BR_SLICE msb cur] | [BR_SINGLE msb]
 	in
 	let i0 = hd indices in
 	merge i0 i0 (tl indices)
@@ -37,8 +56,8 @@ let group_indices indices =
 // prints the results
 let pr_indices indices =
 	let ranges = group_indices indices in
-	let format (SLICE msb lsb) = sprintf "%d:%d" msb lsb
-	 /\ format (SINGLE index) = int2str index in
+	let format (BR_SLICE msb lsb) = sprintf "%d:%d" msb lsb
+	 /\ format (BR_SINGLE index) = int2str index in
     list2str T "[" "," "]" format ranges
 ;
 

--- a/src/bin/fl/preamble.fl
+++ b/src/bin/fl/preamble.fl
@@ -174,7 +174,7 @@ infix 9 @;
 // Return a list with at most cnt elements from l.
 // If the list has more than cnt elements, the tail list is appended
 // after the first cnt elements.
-// Common usage is:  atmost 5 l ["..."]; 
+// Common usage is:  atmost 5 l ["..."];
 // Usage: atmost cnt l trunc_list;
 let atmost cnt l trunc_list = length l <= cnt => l | (firstn cnt l)@trunc_list;
 
@@ -279,7 +279,7 @@ letrec interleave ll = (empty ll) => [] |
                 rm @ (rem (tl ll)) in
         (hdlist ll) @ (interleave (rem ll));
 
-// Take two lists of the same length and return a list of pairs 
+// Take two lists of the same length and return a list of pairs
 letrec zip l1 l2 =
         empty l1 =>
             empty l2 => [] | error "Length mismatch in zip"
@@ -289,8 +289,8 @@ letrec zip l1 l2 =
             (hd l1, hd l2):(zip (tl l1) (tl l2))
 ;
 
-// Take a list of pairs pl and return a pair of lists 
-letrec unzip pl = empty pl => ([],[]) | 
+// Take a list of pairs pl and return a pair of lists
+letrec unzip pl = empty pl => ([],[]) |
 		let res = unzip (tl pl) in
 		let h = hd pl in
 		(((fst h):(fst res)), ((snd h):(snd res)));
@@ -345,7 +345,7 @@ let list2fp_1 fp print_empty_list pre sep post pr_fun l =
 //	pre		    The string that will be prepended before the list
 //	sep		    The separator string between elements
 //	post		    The string that will be appended after the list
-//	pr_fun		    A function that convert an element of the list 
+//	pr_fun		    A function that convert an element of the list
 //			    to a string.
 //	l		    List of elements to print
 let list2fp_2 fp print_empty_list pre sep post pr_fun l =
@@ -382,9 +382,9 @@ overload {** :: *a -> *a -> *a} ipow pow bvpow;
 infix 9 **;
 
 // Convert a list of bools to a signed integer.
-let bl2int bv = 
+let bl2int bv =
     let sz = length bv in
-    (hd bv) => -1*(2**sz-(bv2num bv)) | (bv2num bv) 
+    (hd bv) => -1*(2**sz-(bv2num bv)) | (bv2num bv)
 ;
 
 // Convert a signed integer to a list of bools.
@@ -471,7 +471,7 @@ let bv_ashr_bvbv n amount =
 
 overload bv_ashr bv_ashr bv_ashr_bvbv;
 
-// Compute a substitution for all variables that must take on 
+// Compute a substitution for all variables that must take on
 // some value for cond to be satisfied.
 // For example, if cond = a & b & c' + a & b' & c'
 // forcing cond will return [("a",T),("c",F)]
@@ -643,7 +643,7 @@ let cload filename =
 	|
 	()
     |
-    let full_name = 
+    let full_name =
 	(file_exists full_name1) =>
 	    ((_load full_name1 F) seq full_name1) gen_catch
 	    (\msg.  eprintf "Failed to load |%s|\n%s\n" full_name1 msg)
@@ -662,7 +662,7 @@ end_abstype cload;
 // Replace all current state variables (not ending in _n) with their
 // corresponding next-state variables in all the BDDs in fs.
 // All other variables remain as they were.
-// NOTE: If fs already depends on one of the new next-state variables, 
+// NOTE: If fs already depends on one of the new next-state variables,
 // you will likely not get what you expect, so beware!
 // Usage: bdd_current2next fs;
 let bdd_current2next f =
@@ -676,7 +676,7 @@ let bdd_current2next f =
 // Replace all next-state variables (ending in _n) with their
 // corresponding current-state variables in all the BDDs in fs.
 // All other variables remain as they were.
-// NOTE: If fs already depends on one of the new current-state variables, 
+// NOTE: If fs already depends on one of the new current-state variables,
 // you will likely not get what you expect, so beware!
 // Usage: bdd_next2current fs;
 let bdd_next2current f =
@@ -770,7 +770,7 @@ lettype window = WINDOW {window_name::string};
 // The function returns a handle to the window and a call to get_window_result
 // with this handle will wait to a button to be pressed when pressed,
 // the window will be destroyed and ret_val returned.
-// 
+//
 // NOTE: Only functional in normal (i.e., not -noX) mode!
 let report_result msg_header msg_details return_alts =
     let pre = sprintf "util:report_result {%s} {%s} {"
@@ -797,7 +797,7 @@ let get_window_result window =
 // Also create a list of buttons, one for each (name,ret_val) pair
 // in return_alts. The button will be named "name" and when pressed,
 // the window will be destroyed and ret_val returned.
-// 
+//
 // NOTE: Only functional in normal (i.e., not -noX) mode!
 let report_result_in_file msg msg_file return_alts =
     let pre = sprintf "util:report_result_in_file {%s} {%s} {" msg msg_file then
@@ -832,8 +832,8 @@ cletrec set2iset set =
 // Return the list of elements in the iset. Elements are numbers 1, 2, 3, ...
 cletrec iset2set iset =
     val (ISET i) = iset in
-    i = 0 => [] | 
-    letrec try ci pow = 
+    i = 0 => [] |
+    letrec try ci pow =
         ci = 0 => [] |
         (ci intAND 4294967295) = 0 => try (ci/4294967296) (pow+32) |
         (ci intAND 65535) = 0 => try (ci/65536) (pow+16) |
@@ -880,7 +880,7 @@ infix 7 isubtract;
 // Return the number of elements in iset.
 cletrec ipop_cnt iset =
     val (ISET i) = iset in
-    i = 0 => 0 | 
+    i = 0 => 0 |
     letrec try ci pow =
         ci = 0 => 0 |
         (ci intAND 4294967295) = 0 => try (ci/4294967296) (pow+32) |
@@ -1007,7 +1007,7 @@ let cVARS s cond =
     let cmd4 =
 	sprintf "  cond == F => error \"Constraint unsatisfiable\" |\n"
     in
-    let cmd5 = 
+    let cmd5 =
 	let nds = md_expand_vectors ss then
 	list2str T "  let vs = [" "," "] in\n" (sprintf "\"%s\"") nds
     in
@@ -1281,7 +1281,7 @@ end_abstype param fparam;
 
 let iabs i = i < 0 => -1*i | i;
 let fabs f = f < 0.0 => -1.0*f | f;
-let bevabs {bev::bev} = 
+let bevabs {bev::bev} =
     let is_neg = list2bev [(bev < (int2bev 0))] in
     let neg = (int2bev 0) - bev in
     bev_OR (bev_AND is_neg neg) (bev_AND (bev_NOT is_neg) bev)
@@ -1435,7 +1435,7 @@ install_print_function Pterm;
 
 // Create a bv that satisfies the constraint pred_fun.
 // Pred_fun is given as a function of the generated bv_variable.
-// For example: 
+// For example:
 // bv_constrained_variable "a[4:0]"
 // 			   (\v. v > '0 AND v < '10 AND ((v % '2) = '1));
 //
@@ -1449,7 +1449,7 @@ let bv_constrained_variable vec pred =
 
 // Function that computes the condition under which the bitvector v
 // has exactly one bit high.
-let mutex v = 
+let mutex v =
     v <= '0 => F |
     v = (bv_AND v ('-1*v))
 ;
@@ -1541,7 +1541,7 @@ lettype wexpr =
         |   W_CONST {sz::int} {v::int}
         |   W_NAMED_CONST {name::string} {sz::int} {v::int}
         |   W_VAR {sz::int} {base::string}
-	|   W_EXPLICIT_VAR {sz::int} {name::string}
+        |   W_EXPLICIT_VAR {sz::int} {name::string}
         |   W_AND {a::wexpr} {b::wexpr}
         |   W_OR {a::wexpr} {b::wexpr}
         |   W_NOT {a::wexpr}
@@ -1562,7 +1562,7 @@ lettype wexpr =
         |   W_SLICE {indices::int list} {w::wexpr}
         |   W_NAMED_SLICE {name::string} {indices::int list} {w::wexpr}
         |   W_UPDATE_NAMED_SLICE {base::wexpr}
-				 {name::string} {indices::int list} {new::wexpr}
+                {name::string} {indices::int list} {new::wexpr}
         |   W_CAT {parts::wexpr list}
         |   W_MEM_READ {info::mem} {mem::wexpr} {addr::wexpr}
         |   W_MEM_WRITE {info::mem} {mem::wexpr} {addr::wexpr} {data::wexpr}
@@ -1635,7 +1635,7 @@ letrec DBGwexpr (W_X sz) =
 	    sprintf "(W_CONST %d 0b%0*b)" sz sz v
  /\    DBGwexpr (W_VAR sz base) =
 	    sprintf "(W_VAR %d %s)" sz base
- /\    DBGwexpr (W_EXPLICIT_VAR sz name) = 
+ /\    DBGwexpr (W_EXPLICIT_VAR sz name) =
 	    sprintf "(W_EXPLICIT_VAR %d %s)" sz name
  /\    DBGwexpr (W_AND a b) =
 	    sprintf "(W_AND %s %s)" (DBGwexpr a) (DBGwexpr b)
@@ -1733,7 +1733,7 @@ let bexpr2bdd_void  {b::void} = b;
 add_open_overload bexpr2bdd bexpr2bdd_void;
 let bexpr2bdd_list  l = map (bexpr2bdd ) l;
 add_open_overload bexpr2bdd bexpr2bdd_list;
-let bexpr2bdd_pair  (a,b) = 
+let bexpr2bdd_pair  (a,b) =
     ((bexpr2bdd a), (bexpr2bdd b))
 ;
 add_open_overload bexpr2bdd bexpr2bdd_pair;
@@ -1805,7 +1805,7 @@ non_lazy set_font;
 //
 let vec_interleave vecs = interleave (map md_expand_vector vecs);
 
-// Evaluate expression e inside a context in which all of the GUI, 
+// Evaluate expression e inside a context in which all of the GUI,
 // except Interrupt button(s), is made inactive.
 let busy e =
     (tcl_eval ["i_am_busy"]) fseq

--- a/tutorials/August_24_2020/session_2/2_verilog.fl
+++ b/tutorials/August_24_2020/session_2/2_verilog.fl
@@ -5,7 +5,7 @@ load "ste.fl";
 // For details of the arguments, see the help system.
 
 // A small example (~5k lines of Verilog).
-let p = verilog2pexlif "-IM65C02" "M65C02_Core" [
+let p = verilog2pexlif ("-I"^DIR^"M65C02") "M65C02_Core" [
 						"M65C02_Core.v",
 						"M65C02_MPCv4.v",
 						"M65C02_AddrGen.v",
@@ -16,7 +16,7 @@ let p = verilog2pexlif "-IM65C02" "M65C02_Core" [
 STE_debug (pexlif2fsm p);
 
 // A larger example:
-let p = verilog2pexlif "-Ior1200_hp" "or1200_top" [
+let p = verilog2pexlif ("-I"^DIR^"or1200_hp") "or1200_top" [
 	    "rf_sub.v",
 	    "or1200_alu.v",
 	    "or1200_cfgr.v",


### PR DESCRIPTION
See individual commits:

- whitespace change
- removed redundant functions (update_fn_get_update_fun_lhs and update_fn_get_lhs are the same, same for rhs)
- create new function to group index ranges based on pr_indices. Reworked pr_indices to avoid code duplication. (I noticed there is another copy of pr_indices in an abstract type in the preamble... I haven't touched that one)
- Added size checks to SX and ZX function to avoid "extending" into a smaller size