### PR TITLE
fix: fix cstring import in newer compilers

### DIFF
--- a/IDVII/src/fl/gui/sch_draw/draw_sch.fl
+++ b/IDVII/src/fl/gui/sch_draw/draw_sch.fl
@@ -533,7 +533,10 @@ let gen_draw_inside vfsm canvas cur_draw_level vecs inst_nbr =
 	(flatmap snd (get_visualization_fanins fsm (hd nds) cur_draw_level))
 	subtract nds
     then
-    let phier= tcl_eval [sprintf "set ::sch_info(instance_hier,%s)" canvas] then
+    let phier= 
+		tcl_eval [
+			sprintf "if { ![info exists ::sch_info(draw_level,%s)] } {set ::sch_info(draw_level,%s) 0}" canvas canvas]
+	then
     let hier = sprintf "%si%d/" phier inst_nbr then
     let name =
 	let pfn = get_visualization_pfn fsm (hd nds) cur_draw_level then

--- a/src/doc/fl/tut_code/code_0026.fl
+++ b/src/doc/fl/tut_code/code_0026.fl
@@ -1,6 +1,7 @@
 load "ste.fl";
 let ckt =
   verilog2pexlif
+	F
     "-Iverilog_examples"       // Flags to Yosys, which parses the Verilog for us
     "mux4"                     // Top-level module
     ["small.v", "small_lib.v"] // Files to read and compile

--- a/src/external/yosys/write_pexlif/write_pexlif.cc
+++ b/src/external/yosys/write_pexlif/write_pexlif.cc
@@ -28,6 +28,7 @@
 #include "kernel/celltypes.h"
 #include "kernel/log.h"
 #include <string>
+#include <cstring>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN


### PR DESCRIPTION
strcpy is moved to cstring header. Add the new import to fix compiler error.