### PR TITLE
feat: use bsd editline for stdin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: doxygen
+      - name: install dependency
         run: |
           sudo apt update
-          sudo apt-get install -y doxygen flex bison gawk libz-dev tcl-dev tk-dev libstdc++-11-dev graphviz
+          sudo apt-get install -y doxygen flex bison gawk libz-dev tcl-dev tk-dev libstdc++-11-dev graphviz libeditline-dev
 
       - name: Setup GCC
         shell: bash
@@ -100,4 +100,4 @@ jobs:
       - name: compile vossii
         shell: bash
         run: |
-          make -C src package -j4
+          make -C src install

--- a/src/bin/fl/Makefile
+++ b/src/bin/fl/Makefile
@@ -10,7 +10,7 @@ PLUGIN_DIR ?=$(ROOT_DIR)/plugins
 BASE_FLAGS = $(DEBUG_FLAG) $(OPTIMIZATION_FLAG) $(FL_OPTIONS) \
 	-Wall -Wextra -Werror \
 	-DVERSION_DATE='"$(VERSION_DATE)"' \
-	-DDEFAULT_PLUGIN_DIR='"$(PLUGIN_DIR)"' -DFL_BINARY=1
+	-DDEFAULT_PLUGIN_DIR='"$(PLUGIN_DIR)"' -DFL_BINARY=1 -ledit -lncurses
 
 CFLAGS += $(BASE_FLAGS) $(COMPATIBILITY_FLAG)
 CXXFLAGS += $(BASE_FLAGS) -fpermissive -Wno-error
@@ -20,7 +20,6 @@ ifeq '' '$(findstring clang++,$(CX))'
 else
   FL_LIB_FLAGS = -ldl -fuse-ld=$(subst clang++,lld,$(CX))
 endif
-# Minisat legacy code workaround
 
 INC = -I../../include -I$(MINISAT_DIR)/include $(TCL_INCLUDE) -DROOT_DIR='"$(ROOT_DIR)"'
 LIB = ../../lib/fl_lib.a $(MINISAT_DIR)/lib/libminisat.a

--- a/src/bin/fl/fl.c
+++ b/src/bin/fl/fl.c
@@ -61,8 +61,8 @@ extern string		binary_location;
 extern bool		RCadd_debug_info;
 
 bool	do_parse(bool flush);
+bool	do_parse_stdin(bool flush);
 bool	perform_fl_command(string txt);
-void	Start_stdin_parsing();
 
 /* ===================== Local variables defined ===================== */
 #define TCL_CMD_BUF_SZ	    16384
@@ -639,7 +639,6 @@ fl_main(int argc, char *argv[])
         FP(stdout_fp, "   /    VossII %s (%s)\n", FL_VERSION, VERSION_DATE);
         FP(stdout_fp, "VOSS-LIBRARY-DIRECTORY = %s\n", RCDefault_dir);
         FP(stdout_fp, "Temporary files directory = %s\n", Voss_tmp_dir);
-        Start_stdin_parsing();
         if( start_file != NULL ) {
 	    // Create a dummy file that loads preamble.fl and start_file
 	    FILE *fp;
@@ -669,13 +668,17 @@ fl_main(int argc, char *argv[])
 	    Sprintf(buf, "%s/preamble.fl", binary_location);
 	    Read_from_file(buf, FALSE, FALSE);
 	}
-        Emit_prompt("");
         Set_default_break_handler();
         while(1) {
             switch( setjmp(toplevel_eval_env) ) {
                 case 0:
                     /* All ok */
-                    do_parse(TRUE);
+                    if (gui_mode) {
+                        Emit_prompt("");
+                        do_parse(TRUE);
+                    }
+                    else
+                        do_parse_stdin(TRUE);
                     break;
                 case 2:
                     /* User interrupt with "return to top" */

--- a/src/bin/fl/lexer
+++ b/src/bin/fl/lexer
@@ -17,6 +17,8 @@ symbol	[!%&$#+\-*/:<=>?@\\~`'^|\_]
 #include "fl.h"
 #include "y.tab.h"
 #include <unistd.h>
+#include <stdlib.h>
+#include <editline/readline.h>
 
 #define YY_DECL                 int yylex (YYSTYPE *lvalp)
 
@@ -470,6 +472,50 @@ do_parse(bool flush)
 }
 
 bool
+do_parse_stdin(bool flush)
+{
+    bool ok;
+    eval_ctx_rec ctx;
+    Record_eval_context(&ctx);
+    jmp_buf eval_env;
+    start_envp = &eval_env;
+    switch( setjmp(*start_envp) ) {
+        case 0:
+            /* All ok */
+	    if( flush ) { YY_FLUSH_BUFFER; }
+            /* credit: https://sourceforge.net/p/flex/mailman/message/23586115/ */
+            char *line, *prompt = "voss2>";
+            rl_initialize();
+            YY_BUFFER_STATE bp;
+            while( 1 )
+              {
+                line = readline(prompt);
+                if( line == 0 )
+                  break;
+                else if( strlen(line) > 0)
+                  {
+                    add_history(line);
+                    bp= yy_scan_string( line );
+                    yy_switch_to_buffer(bp);
+                    ok = yyparse();
+                    yy_delete_buffer(bp);
+                  }
+               }
+            break;
+        case 1:
+            /* Return from a failure */
+            ok = FALSE;
+            break;
+        default:
+            DIE("Should never happen");
+            break;
+    }
+    Restore_eval_context(&ctx);
+    return ok;
+}
+
+
+bool
 perform_fl_command(string txt)
 {
     YY_BUFFER_STATE old_buffer = YY_CURRENT_BUFFER;
@@ -533,13 +579,6 @@ end_extern_parsing(string cmd)
     reading_external_parse_inps = TRUE;
     pre_ext_parse_line_nbr = line_nbr;
     yypush_buffer_state(yy_create_buffer(res_fid, YY_BUF_SIZE));
-}
-
-void
-Start_stdin_parsing()
-{
-    yyin = stdin;
-    yy_switch_to_buffer(yy_create_buffer(yyin, YY_BUF_SIZE));
 }
 
 int


### PR DESCRIPTION
This cleans up the parser code to use bsd editline. This brings command
history support as well as standard command support.

We switch to dynamic linking as well in the ci

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>