### PR TITLE
fix: fix segfault under clang

### DIFF
--- a/src/bin/fl/fsm.c
+++ b/src/bin/fl/fsm.c
@@ -538,7 +538,7 @@ Fsm_Init()
 
     create_hash(&state_holding_tbl, 50, str_hash, str_equ);
     string *p = state_holding_names;
-    while( *p ) {
+    for (unsigned int i = 0; i < sizeof(state_holding_names) / sizeof(string) ; i++) {
 	string n = wastrsave(&strings, *p);
 	insert_hash(&state_holding_tbl, n, n);
 	p++;


### PR DESCRIPTION
This fixes an issue where p could become out of bounds when traversing the pointer array