### PR TITLE
fix: fix the case for builtin

### DIFF
--- a/src/bin/fl/symbol.c
+++ b/src/bin/fl/symbol.c
@@ -2264,8 +2264,9 @@ static bool
 built_in(string filename)
 {
     int len = strlen(filename);
+    if (strcmp(filename, "builtin") == 0) { return TRUE; }
     if( len < builtins_len ) { return FALSE; }
-    return( strcmp(filename + (len-builtins_len), "builtins.fl") == 0 );
+    return (strcmp(filename + (len-builtins_len), "builtins.fl") == 0);
 }
 
 static g_ptr


### PR DESCRIPTION
This fixes an issue where previously builtin functions could show up with a clickable link that links to `builtin`, causing a crash when it's clicked. Checking help for `get_arity` function would reproduce this issue.